### PR TITLE
Switch to rake-compiler for building binary gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,1 @@
+gem 'rake-compiler', '>= 0.7.5'

--- a/lib/bcrypt.rb
+++ b/lib/bcrypt.rb
@@ -2,18 +2,11 @@
 
 if RUBY_PLATFORM == "java"
   require 'java'
-  $CLASSPATH << File.expand_path(File.join(File.dirname(__FILE__), "..", "ext", "jruby"))
 else
-  begin
-    require "bcrypt_ext"
-  rescue LoadError
-    extdir = File.expand_path(File.join(File.dirname(__FILE__), "..", "ext", "mri"))
-    $LOAD_PATH.unshift(extdir) if File.directory?(extdir) && !$LOAD_PATH.include?(extdir)
-    require "bcrypt_ext"
-  end
-
   require "openssl"
 end
+
+require 'bcrypt_ext'
 
 # A Ruby library implementing OpenBSD's bcrypt()/crypt_blowfish algorithm for
 # hashing passwords.


### PR DESCRIPTION
This makes it trivial to build win32 binary gems that support both 1.8 and 1.9, allowing rails to support BCrypt as the default SecurePassword implementation (https://github.com/rails/rails/commit/39b5ea6e01f6fc652cc63ab4e7e701cfaa9f9405).
