### PR TITLE
Sun C compiler does not accept -Wall flag.

### DIFF
--- a/ext/mri/extconf.rb
+++ b/ext/mri/extconf.rb
@@ -35,6 +35,6 @@ clean:
 else
   require "mkmf"
   dir_config("bcrypt_ext")
-  CONFIG['CC'] << " -Wall "
+  CONFIG['CC'] << " -Wall " if ! CONFIG['GCC'].nil?
   create_makefile("bcrypt_ext")
 end


### PR DESCRIPTION
Hello,

While trying to install Rails 3.1.0rc*, I was having troubles getting bcrypt-ruby to install.  The Sun WorkShop C compiler does not accept the -Wall flag.  The proposed patch fixes this issue.  Admittedly, it may be too restrictive, but it is a step in the right direction.

Thank you,
Brett
