### PR TITLE
Here is patch that gets VC 2010 working.  However, I'm worried about a conflict between ruby's crypt.c file (line 500) and the one in ow-crypt.h.  Is this an issue?

### DIFF
--- a/ext/mri/ow-crypt.h
+++ b/ext/mri/ow-crypt.h
@@ -7,10 +7,11 @@
 #define _OW_CRYPT_H
 
 #undef __CONST
-#ifdef __GNUC__
+#if defined __GNUC__
 #define __CONST __const
+#elif defined _MSC_VER
+#define __CONST const
 #else
-#define __CONST
 #endif
 
 #ifndef __SKIP_GNU


### PR DESCRIPTION
C:\MinGW\local\src\bcrypt-ruby\ext\mri\ow-crypt.h(17) : error C4028: formal parameter 1 different from declaration
C:\MinGW\local\src\bcrypt-ruby\ext\mri\ow-crypt.h(17) : error C4028: formal parameter 2 different from declaration
C:\MinGW\local\src\bcrypt-ruby\ext\mri\ow-crypt.h(17) : warning C4273: 'crypt' : inconsistent dll linkage
        c:\mingw\local\ruby\include\ruby-1.9.1\ruby/missing.h(77) : see previous definition of 'crypt'

The fix is to define _CONST as const to match the declaration in missing.h.

Note though that Ruby defines a crypt method in crypt.c.  Is this a problem?
