### PR TITLE
Fix crash on REE/OS X: use ruby_strdup()/xfree() instead of strdup()/free() when possible

### DIFF
--- a/ext/mri/bcrypt_ext.c
+++ b/ext/mri/bcrypt_ext.c
@@ -44,7 +44,7 @@ static VALUE bc_salt(VALUE self, VALUE prefix, VALUE count, VALUE input) {
     if(!salt) return Qnil;
 
     str_salt = rb_str_new2(salt);
-    free(salt);
+    xfree(salt);
 
     return str_salt;
 }
@@ -72,7 +72,7 @@ static VALUE bc_crypt(VALUE self, VALUE key, VALUE setting) {
 
     out = rb_str_new(data, size - 1);
 
-    free(data);
+    xfree(data);
 
     return out;
 }

--- a/ext/mri/wrapper.c
+++ b/ext/mri/wrapper.c
@@ -23,6 +23,8 @@
 #endif
 #endif
 
+#include <util.h>
+
 #define CRYPT_OUTPUT_SIZE		(7 + 22 + 31 + 1)
 #define CRYPT_GENSALT_OUTPUT_SIZE	(7 + 22 + 1)
 
@@ -234,7 +236,7 @@ char *__crypt_gensalt_ra(__CONST char *prefix, unsigned long count,
 		input, size, output, sizeof(output));
 
 	if (retval) {
-		retval = strdup(retval);
+		retval = ruby_strdup(retval);
 #ifndef __GLIBC__
 		/* strdup(3) on glibc sets errno, so we don't need to bother */
 		if (!retval)


### PR DESCRIPTION
On Ruby Enterprise Edition + tcmalloc + OS X, strdup() uses libc's malloc to allocate the string while free() calls from bcrypt_ext call out to the memory allocator that Ruby is linked to, namely tcmalloc in this case. This results in a crash. ruby_strdup() and xfree() use whatever memory allocator Ruby is linked to, thereby solving the problem.
