### PR TITLE
Allow bcrypt-ruby to install with jruby on windows

### DIFF
--- a/bcrypt-ruby.gemspec
+++ b/bcrypt-ruby.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |s|
   s.rdoc_options += ['--title', 'bcrypt-ruby', '--line-numbers', '--inline-source', '--main', 'README.md']
   s.extra_rdoc_files += ['README.md', 'COPYING', 'CHANGELOG', *Dir['lib/**/*.rb']]
 
-  s.extensions = 'ext/mri/extconf.rb'
-
   s.authors = ["Coda Hale"]
   s.email = "coda.hale@gmail.com"
   s.homepage = "http://bcrypt-ruby.rubyforge.org"


### PR DESCRIPTION
This should allow bcrypt-ruby to install with jruby/windows. Fixes issue #28.

Not really sure what this will do to other platforms. From looking at the rake compiler documentation it looks like extconf.rb is the default extension configuration file, which is what bcrypt-ruby uses so my guess is that things will still work. But I also have no real understanding of how ruby compiler even fits into the gem installation process so hopefully someone with more knowledge of the rubygems native extension stuff can help me improve this.
