### PR TITLE
BCrypt::Errors::* descend from new BCrypt::Error.

### DIFF
--- a/lib/bcrypt.rb
+++ b/lib/bcrypt.rb
@@ -11,11 +11,13 @@ require 'bcrypt_ext'
 # A Ruby library implementing OpenBSD's bcrypt()/crypt_blowfish algorithm for
 # hashing passwords.
 module BCrypt
+
+  class Error < StandardError; end
   module Errors
-    class InvalidSalt   < StandardError; end  # The salt parameter provided to bcrypt() is invalid.
-    class InvalidHash   < StandardError; end  # The hash parameter provided to bcrypt() is invalid.
-    class InvalidCost   < StandardError; end  # The cost parameter provided to bcrypt() is invalid.
-    class InvalidSecret < StandardError; end  # The secret parameter provided to bcrypt() is invalid.
+    class InvalidSalt   < BCrypt::Error; end  # The salt parameter provided to bcrypt() is invalid.
+    class InvalidHash   < BCrypt::Error; end  # The hash parameter provided to bcrypt() is invalid.
+    class InvalidCost   < BCrypt::Error; end  # The cost parameter provided to bcrypt() is invalid.
+    class InvalidSecret < BCrypt::Error; end  # The secret parameter provided to bcrypt() is invalid.
   end
 
   # A Ruby wrapper for the bcrypt() C extension calls and the Java calls.

--- a/spec/bcrypt/error_spec.rb
+++ b/spec/bcrypt/error_spec.rb
@@ -2,26 +2,36 @@ require File.expand_path(File.join(File.dirname(__FILE__), "..", "spec_helper"))
 
 describe "Errors" do
 
-  shared_examples "StandardError" do
-    it "is is rescued as a StandardError" do
+  shared_examples "descends from StandardError" do
+    it "can be rescued as a StandardError" do
       described_class.should < StandardError
     end
   end
 
+  shared_examples "descends from BCrypt::Error" do
+    it "can be rescued as a BCrypt::Error" do
+      described_class.should < BCrypt::Error
+    end
+  end
+
+  describe BCrypt::Error do
+    include_examples "descends from StandardError"
+  end
+
   describe BCrypt::Errors::InvalidCost do
-    it_behaves_like "StandardError"
+    include_examples "descends from BCrypt::Error"
   end
 
   describe BCrypt::Errors::InvalidHash do
-    it_behaves_like "StandardError"
+    include_examples "descends from BCrypt::Error"
   end
 
   describe BCrypt::Errors::InvalidSalt do
-    it_behaves_like "StandardError"
+    include_examples "descends from BCrypt::Error"
   end
 
   describe BCrypt::Errors::InvalidSecret do
-    it_behaves_like "StandardError"
+    include_examples "descends from BCrypt::Error"
   end
 
 end


### PR DESCRIPTION
The addition of a root BCrypt::Error class makes error handling far less verbose, and does not impact backwards compatibility. It also means code which rescues `BCrypt::Error` today will handle `BCrypt::Errors::InvalidMoonPhase` if it's added in future.
## Before

``` ruby
begin
  # some BCrypt call
rescue BCrypt::Errors::InvalidSalt, BCrypt::Errors::InvalidHash,
       BCrypt::Errors::InvalidCost, BCrypt::Errors::InvalidSecret
  # handle error
end
```
## After

``` ruby
begin
  # ...
rescue BCrypt::Error
  # ...
end
```

RSpec output:

```
Errors
  BCrypt::Error
    can be rescued as a StandardError
  BCrypt::Errors::InvalidCost
    can be rescued as a BCrypt::Error
  BCrypt::Errors::InvalidHash
    can be rescued as a BCrypt::Error
  BCrypt::Errors::InvalidSalt
    can be rescued as a BCrypt::Error
  BCrypt::Errors::InvalidSecret
    can be rescued as a BCrypt::Error
```
