### PR TITLE
Password cost should be set to DEFAULT_COST if nil

### DIFF
--- a/lib/bcrypt.rb
+++ b/lib/bcrypt.rb
@@ -117,7 +117,7 @@ module BCrypt
   #
   #   include BCrypt
   #
-  #   # hash a user's password  
+  #   # hash a user's password
   #   @password = Password.create("my grand secret")
   #   @password #=> "$2a$10$GtKs1Kbsig8ULHZzO1h2TetZfhO4Fmlxphp8bVKnUlZCBYYClPohG"
   #
@@ -152,9 +152,10 @@ module BCrypt
       # Example:
       #
       #   @password = BCrypt::Password.create("my secret", :cost => 13)
-      def create(secret, options = { :cost => BCrypt::Engine::DEFAULT_COST })
-        raise ArgumentError if options[:cost] > 31
-        Password.new(BCrypt::Engine.hash_secret(secret, BCrypt::Engine.generate_salt(options[:cost]), options[:cost]))
+      def create(secret, options = {})
+        cost = options[:cost] || BCrypt::Engine::DEFAULT_COST
+        raise ArgumentError if cost > 31
+        Password.new(BCrypt::Engine.hash_secret(secret, BCrypt::Engine.generate_salt(cost), cost))
       end
     end
 

--- a/spec/bcrypt/password_spec.rb
+++ b/spec/bcrypt/password_spec.rb
@@ -40,6 +40,14 @@ describe "Reading a hashed password" do
     }.should raise_error(ArgumentError)
   end
 
+  specify "the cost should be set to the default if nil" do
+    BCrypt::Password.create("hello", :cost => nil).cost.should equal(BCrypt::Engine::DEFAULT_COST)
+  end
+
+  specify "the cost should be set to the default if empty hash" do
+    BCrypt::Password.create("hello", {}).cost.should equal(BCrypt::Engine::DEFAULT_COST)
+  end
+
   specify "should read the version, cost, salt, and hash" do
     password = BCrypt::Password.new(@hash)
     password.version.should eql("2a")


### PR DESCRIPTION
While working on a Pull Request for the `SecurePassword` module in Rails, @jeremy and I noticed that passing a `cost` of `nil` to `BCrypt::Password#create` causes an exception. We thought it'd be nice to fall back to `DEFAULT_COST` instead. 
