### PR TITLE
Change == to is_password?

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The bcrypt-ruby gem is available on the following ruby platforms:
 
     def login
       @user = User.find_by_email(params[:email])
-      if @user.password == params[:password]
+      if @user.password.is_password?(params[:password])
         give_token
       else
         redirect_to home_url
@@ -89,14 +89,14 @@ The bcrypt-ruby gem is available on the following ruby platforms:
     my_password = BCrypt::Password.create("my password")
       #=> "$2a$10$vI8aWBnW3fID.ZQ4/zo1G.q1lRps.9cGLcZEiGDMVr5yUP1KUOYTa"
 
-    my_password.version              #=> "2a"
-    my_password.cost                 #=> 10
-    my_password == "my password"     #=> true
-    my_password == "not my password" #=> false
+    my_password.version                         #=> "2a"
+    my_password.cost                            #=> 10
+    my_password.is_password?("my password")     #=> true
+    my_password.is_password?("not my password") #=> false
 
     my_password = BCrypt::Password.new("$2a$10$vI8aWBnW3fID.ZQ4/zo1G.q1lRps.9cGLcZEiGDMVr5yUP1KUOYTa")
-    my_password == "my password"     #=> true
-    my_password == "not my password" #=> false
+    my_password.is_password?("my password")     #=> true
+    my_password.is_password?("not my password") #=> false
 
 Check the rdocs for more details -- BCrypt, BCrypt::Password.
 

--- a/spec/bcrypt/password_spec.rb
+++ b/spec/bcrypt/password_spec.rb
@@ -64,11 +64,11 @@ describe "Comparing a hashed password with a secret" do
   end
 
   specify "should compare successfully to the original secret" do
-    (@password == @secret).should be(true)
+    (@password.is_password?(@secret)).should be(true)
   end
 
   specify "should compare unsuccessfully to anything besides original secret" do
-    (@password == "@secret").should be(false)
+    (@password.is_password?("@secret")).should be(false)
   end
 end
 


### PR DESCRIPTION
This is more a discussion starter then a complete pull request.
I have found that the use of == confuses a lot of people who are making the switch to BCrypt, thinking that somehow their password is decrypted to a plaintext string which is then compared to the posted password.
Also overriding == is bad practice IMHO, because it gives unexpected behaviour here.
I've changed the read me to reflect this, which makes things a bit clearer for the first time user.  If you think this is a good idea, then it would be smart to change the actually implementation as well.
