### PR TITLE
Bump RSpec version.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    diff-lcs (1.1.2)
+    diff-lcs (1.2.4)
     json (1.7.3)
     json (1.7.3-java)
     rake (0.8.7)
@@ -14,14 +14,14 @@ GEM
       rake
     rdoc (3.12)
       json (~> 1.4)
-    rspec (2.5.0)
-      rspec-core (~> 2.5.0)
-      rspec-expectations (~> 2.5.0)
-      rspec-mocks (~> 2.5.0)
-    rspec-core (2.5.1)
-    rspec-expectations (2.5.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.5.0)
+    rspec (2.13.0)
+      rspec-core (~> 2.13.0)
+      rspec-expectations (~> 2.13.0)
+      rspec-mocks (~> 2.13.0)
+    rspec-core (2.13.1)
+    rspec-expectations (2.13.0)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.13.1)
 
 PLATFORMS
   java


### PR DESCRIPTION
Alternate fix for https://github.com/codahale/bcrypt-ruby/pull/60 based on feedback from @tmm1
