### PR TITLE
Allow a default cost to be set externally

### DIFF
--- a/lib/bcrypt.rb
+++ b/lib/bcrypt.rb
@@ -36,6 +36,11 @@ module BCrypt
       private_class_method :__bc_crypt
     end
 
+    class << self
+      attr_accessor :cost
+    end
+    self.cost = DEFAULT_COST
+
     # Given a secret and a valid salt (see BCrypt::Engine.generate_salt) calculates
     # a bcrypt() password hash.
     def self.hash_secret(secret, salt, cost = nil)
@@ -59,7 +64,7 @@ module BCrypt
     end
 
     # Generates a random salt with a given computational cost.
-    def self.generate_salt(cost = DEFAULT_COST)
+    def self.generate_salt(cost = self.cost)
       cost = cost.to_i
       if cost > 0
         if cost < MIN_COST
@@ -155,7 +160,7 @@ module BCrypt
       #
       #   @password = BCrypt::Password.create("my secret", :cost => 13)
       def create(secret, options = {})
-        cost = options[:cost] || BCrypt::Engine::DEFAULT_COST
+        cost = options[:cost] || BCrypt::Engine.cost
         raise ArgumentError if cost > 31
         Password.new(BCrypt::Engine.hash_secret(secret, BCrypt::Engine.generate_salt(cost), cost))
       end

--- a/spec/bcrypt/password_spec.rb
+++ b/spec/bcrypt/password_spec.rb
@@ -48,6 +48,15 @@ describe "Reading a hashed password" do
     BCrypt::Password.create("hello", {}).cost.should equal(BCrypt::Engine::DEFAULT_COST)
   end
 
+  specify "the cost should be set to the passed value if provided" do
+    BCrypt::Password.create("hello", :cost => 5).cost.should equal(5)
+  end
+
+  specify "the cost should be set to the global value if set" do
+    BCrypt::Engine.cost = 5
+    BCrypt::Password.create("hello").cost.should equal(5)
+  end
+
   specify "should read the version, cost, salt, and hash" do
     password = BCrypt::Password.new(@hash)
     password.version.should eql("2a")


### PR DESCRIPTION
Currently, if you're using bcrypt-ruby externally (like in a Rails app), you can't re-set the default cost to match your own business concerns.

It seems like a common desire to do something like `BCrypt::Engine::DEFAULT_COST = 12` in your config/environments/production.rb for **SUPER ENTERPRISE SECURITY™**, or a lower value if you want auth requests to be a little snappier (like for an API that requires passing through a password with every request).

Re-setting the constant _works_, but causes a `"warning: already initialized constant DEFAULT_COST"`, which makes sense, because, y'know, "constant".

This fix makes `cost` a settable global attribute, allowing you to set `BCrypt::Engine.cost = some_value` externally, defaulting internally to `DEFAULT_COST`.
