### PR TITLE
Custom getter/setter for BCrypt::Engine.cost

### DIFF
--- a/lib/bcrypt.rb
+++ b/lib/bcrypt.rb
@@ -36,10 +36,15 @@ module BCrypt
       private_class_method :__bc_crypt
     end
 
-    class << self
-      attr_accessor :cost
+    @cost = nil
+
+    def self.cost
+      @cost || DEFAULT_COST
     end
-    self.cost = DEFAULT_COST
+
+    def self.cost=(cost)
+      @cost = cost
+    end
 
     # Given a secret and a valid salt (see BCrypt::Engine.generate_salt) calculates
     # a bcrypt() password hash.

--- a/spec/bcrypt/password_spec.rb
+++ b/spec/bcrypt/password_spec.rb
@@ -55,6 +55,21 @@ describe "Reading a hashed password" do
   specify "the cost should be set to the global value if set" do
     BCrypt::Engine.cost = 5
     BCrypt::Password.create("hello").cost.should equal(5)
+    # unset the global value to not affect other tests
+    BCrypt::Engine.cost = nil
+  end
+
+  specify "the cost should be set to an overridden constant for backwards compatibility" do
+    # suppress "already initialized constant" warning
+    old_verbose, $VERBOSE = $VERBOSE, nil
+    old_default_cost = BCrypt::Engine::DEFAULT_COST
+
+    BCrypt::Engine::DEFAULT_COST = 5
+    BCrypt::Password.create("hello").cost.should equal(5)
+
+    # reset default to not affect other tests
+    BCrypt::Engine::DEFAULT_COST = old_default_cost
+    $VERBOSE = old_verbose
   end
 
   specify "should read the version, cost, salt, and hash" do


### PR DESCRIPTION
To maintain backwards compatibility for people who were manually overriding the `BCrypt::Engine::DEFAULT_COST` constant externally.

Via @tmm1 on https://github.com/codahale/bcrypt-ruby/pull/63
