### PR TITLE
Add docs for new BCrypt::Engine.cost attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,20 @@ The default cost factor used by bcrypt-ruby is 10, which is fine for session-bas
 stateless authentication architecture (e.g., HTTP Basic Auth), you will want to lower the cost factor to reduce your
 server load and keep your request times down. This will lower the security provided you, but there are few alternatives.
 
+To change the default cost factor used by bcrypt-ruby, use `BCrypt::Engine.cost = new_value`:
+
+    BCrypt::Password.create('secret').cost
+      #=> 10, the default provided by bcrypt-ruby
+
+    # set a new default cost
+    BCrypt::Engine.cost = 8
+    BCrypt::Password.create('secret').cost
+      #=> 8
+
+The default cost can be overridden as needed by passing an options hash with a different cost:
+
+    BCrypt::Password.create('secret', :cost => 6).cost  #=> 6
+
 ## More Information
 
 `bcrypt()` is currently used as the default password storage hash in OpenBSD, widely regarded as the most secure operating

--- a/lib/bcrypt.rb
+++ b/lib/bcrypt.rb
@@ -38,10 +38,25 @@ module BCrypt
 
     @cost = nil
 
+    # Returns the cost factor that will be used if one is not specified when
+    # creating a password hash.  Defaults to DEFAULT_COST if not set.
     def self.cost
       @cost || DEFAULT_COST
     end
 
+    # Set a default cost factor that will be used if one is not specified when
+    # creating a password hash.
+    #
+    # Example:
+    #
+    #   BCrypt::Engine::DEFAULT_COST            #=> 10
+    #   BCrypt::Password.create('secret').cost  #=> 10
+    #
+    #   BCrypt::Engine.cost = 8
+    #   BCrypt::Password.create('secret').cost  #=> 8
+    #
+    #   # cost can still be overridden as needed
+    #   BCrypt::Password.create('secret', :cost => 6).cost  #=> 6
     def self.cost=(cost)
       @cost = cost
     end


### PR DESCRIPTION
Shame on me for not adding docs in the first place.

See https://github.com/codahale/bcrypt-ruby/pull/63 and https://github.com/codahale/bcrypt-ruby/pull/64 for the feature implementation documented here.

/cc @tmm1

(Fun fact: submitting this from 30,000 feet up in the air!  Internet on airplanes!  The future!)
