### PR TITLE
Remove sudo from gem installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ re-hash those passwords. This vulernability only affected the JRuby gem.
 
 ## How to install bcrypt
 
-    sudo gem install bcrypt-ruby
+    gem install bcrypt-ruby
 
 The bcrypt-ruby gem is available on the following ruby platforms:
 


### PR DESCRIPTION
Is there any good reason to be recommending users install with sudo?

Everything seems to work sans sudo, and since gems can execute arbitrary code, installing with sudo [can get dangerous](https://github.com/wmorgan/killergem) if anyone manages to hijack this gem or one if it's dependencies on RubyGems.

If a user _wants_ to install with sudo, they certainly can, and then they are assuming all the risk by being explicit. I don't think that we should be actively recommending it.
