### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+rvm:
+  - "1.8.7"
+  - "1.9.2"
+  - "1.9.3"
+  - "2.0.0"
+  - jruby-18mode
+  - jruby-19mode
+  - rbx-18mode
+  - rbx-19mode
+script: bundle exec rake

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ An easy way to keep your users' passwords secure.
 * http://bcrypt-ruby.rubyforge.org/
 * http://github.com/codahale/bcrypt-ruby/tree/master
 
+[![Build Status](https://travis-ci.org/codahale/bcrypt-ruby.png?branch=master)](https://travis-ci.org/codahale/bcrypt-ruby)
+
 ## Why you should use `bcrypt()`
 
 If you store user passwords in the clear, then an attacker who steals a copy of your database has a giant list of emails


### PR DESCRIPTION
This adds Travis CI to the repo.

Note: this only _fake_ adds it.  I added it to my branch to confirm that the `.travis.yml` file works, and that we're passing on all versions added:

![](https://www.evernote.com/shard/s233/sh/53c111f3-dcda-40a6-97d3-8c5686ea3a68/86c2ed961d0608f4cbe6190b677856da/res/96f6f0a8-3d53-4a83-a866-0c2123078b5e/Travis_CI_-_Free_Hosted_Continuous_Integration_Platform_for_the_Open_Source_Community-20130506-222914.jpg.jpg?resizeSmall&width=832)

You'll need to activate the GitHub service hook for the main repo, but that should be all that's necessary -- merging the pull req should fire the hook and trigger the first build.

See [the Travis getting started guide](http://about.travis-ci.org/docs/user/getting-started/) for more info, and here's [the page for my fork's builds](https://travis-ci.org/tjschuck/bcrypt-ruby) if you're curious.
