### PR TITLE
Bump gem version to 3.1.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,9 +39,14 @@
 2.1.2  Sep 16 2009
   - Fixed support for Solaris, OpenSolaris.
 
-3.0.0 Aug 24, 2011
+3.0.0  Aug 24 2011
   - Bcrypt C implementation replaced with a public domain implementation.
   - License changed to MIT
 
-3.0.1
+3.0.1  Sep 12 2011
   - create raises an exception if the cost is higher than 31. GH #27
+
+3.1.0  May 07 2013
+  - Add BCrypt::Password.valid_hash?(str) to check if a string is a valid bcrypt password hash
+  - BCrypt::Password cost should be set to DEFAULT_COST if nil
+  - Add BCrypt::Engine.cost attribute for getting/setting a default cost externally

--- a/bcrypt-ruby.gemspec
+++ b/bcrypt-ruby.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'bcrypt-ruby'
-  s.version = '3.0.1'
+  s.version = '3.1.0'
 
   s.summary = "OpenBSD's bcrypt() password hashing algorithm."
   s.description = <<-EOF


### PR DESCRIPTION
Per http://semver.org, since the last version, "new, backwards compatible functionality [has been] introduced to the public API", so it should be incremented on the minor version.

Since there was no comment on https://github.com/codahale/bcrypt-ruby/pull/67, I'm not sure if you agree with the restructuring there.  If you agree with that one (or just want to discuss it on that pull request), you can just address this one _after_ that one.  If you disagree with the restructuring, that's a-okay with me (just a matter of preference), but I'd still like the gem version bumped so I can start using this version without needing git refs.

Thanks!
