### PR TITLE
Removing not used variable cost.

### DIFF
--- a/lib/bcrypt/engine.rb
+++ b/lib/bcrypt/engine.rb
@@ -42,13 +42,9 @@ module BCrypt
 
     # Given a secret and a valid salt (see BCrypt::Engine.generate_salt) calculates
     # a bcrypt() password hash.
-    def self.hash_secret(secret, salt, cost = nil)
+    def self.hash_secret(secret, salt, _ = nil)
       if valid_secret?(secret)
         if valid_salt?(salt)
-          if cost.nil?
-            cost = autodetect_cost(salt)
-          end
-
           if RUBY_PLATFORM == "java"
             Java.bcrypt_jruby.BCrypt.hashpw(secret.to_s, salt.to_s)
           else

--- a/lib/bcrypt/password.rb
+++ b/lib/bcrypt/password.rb
@@ -43,7 +43,7 @@ module BCrypt
       def create(secret, options = {})
         cost = options[:cost] || BCrypt::Engine.cost
         raise ArgumentError if cost > 31
-        Password.new(BCrypt::Engine.hash_secret(secret, BCrypt::Engine.generate_salt(cost), cost))
+        Password.new(BCrypt::Engine.hash_secret(secret, BCrypt::Engine.generate_salt(cost)))
       end
 
       def valid_hash?(h)


### PR DESCRIPTION
The cost is presumably calculated by looking at the salt, therefor it's
not used by the C or Java implementations.
Also removing autodetection of the cost, since that is useless, when
not using it.
