### PR TITLE
Rename gem from bcrypt-ruby to bcrypt

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,34 +1,34 @@
 PATH
   remote: .
   specs:
-    bcrypt-ruby (3.1.2)
+    bcrypt (3.1.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.2.4)
-    json (1.7.3)
-    json (1.7.3-java)
+    diff-lcs (1.2.5)
+    json (1.8.1)
+    json (1.8.1-java)
     rake (10.1.0)
-    rake-compiler (0.9.1)
+    rake-compiler (0.9.2)
       rake
-    rdoc (3.12)
+    rdoc (4.0.1)
       json (~> 1.4)
-    rspec (2.13.0)
-      rspec-core (~> 2.13.0)
-      rspec-expectations (~> 2.13.0)
-      rspec-mocks (~> 2.13.0)
-    rspec-core (2.13.1)
-    rspec-expectations (2.13.0)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.7)
+    rspec-expectations (2.14.4)
       diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.13.1)
+    rspec-mocks (2.14.4)
 
 PLATFORMS
   java
   ruby
 
 DEPENDENCIES
-  bcrypt-ruby!
+  bcrypt!
   rake-compiler (~> 0.9.0)
   rdoc
   rspec

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ security experts is not a professional response to risk.
 
 `bcrypt()` allows you to easily harden your application against these kinds of attacks.
 
-*Note*: JRuby versions of bcrypt-ruby `<= 2.1.3` had a [security
+*Note*: JRuby versions of bcrypt `<= 2.1.3` had a [security
 vulnerability](http://www.mindrot.org/files/jBCrypt/internat.adv) that
 was fixed in `>= 2.1.4`. If you used a vulnerable version to hash
 passwords with international characters in them, you will need to
@@ -25,9 +25,9 @@ re-hash those passwords. This vulnerability only affected the JRuby gem.
 
 ## How to install bcrypt
 
-    gem install bcrypt-ruby
+    gem install bcrypt
 
-The bcrypt-ruby gem is available on the following ruby platforms:
+The bcrypt gem is available on the following ruby platforms:
 
 * JRuby
 * RubyInstaller 1.8, 1.9, and 2.0 builds on win32

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ CLOBBER.include(
   "doc/coverage",
   "pkg"
 )
-GEMSPEC = eval(File.read(File.expand_path("../bcrypt-ruby.gemspec", __FILE__)))
+GEMSPEC = eval(File.read(File.expand_path("../bcrypt.gemspec", __FILE__)))
 
 task :default => [:compile, :spec]
 

--- a/bcrypt.gemspec
+++ b/bcrypt.gemspec
@@ -1,5 +1,5 @@
 Gem::Specification.new do |s|
-  s.name = 'bcrypt-ruby'
+  s.name = 'bcrypt'
   s.version = '3.1.2'
 
   s.summary = "OpenBSD's bcrypt() password hashing algorithm."


### PR DESCRIPTION
It makes sense for this repository to be named `bcrypt-ruby`, to avoid ambiguity with other bcrypt libraries, but the gem name need not include `-ruby`, since the `rubygems` package manager is tightly coupled to the Ruby language. Just as the [`sqlite3-ruby` gem was renamed to `sqlite`](https://github.com/sparklemotion/sqlite3-ruby/commit/59855b543f2506829403c1d91f9c93c84298ade0), this package’s name should just be `bcrypt`.

This also increases consistency between the library’s name and the way it is required.

``` ruby
require 'bcrypt'
```

I’ve also removed links to the old RubyForge project, which no longer work.
