### PR TITLE
Raise error when passed secret includes null byte.

### DIFF
--- a/lib/bcrypt/engine.rb
+++ b/lib/bcrypt/engine.rb
@@ -83,7 +83,7 @@ module BCrypt
 
     # Returns true if +secret+ is a valid bcrypt() secret, false if not.
     def self.valid_secret?(secret)
-      secret.respond_to?(:to_s)
+      secret.respond_to?(:to_s) && !secret.to_s.include?("\0")
     end
 
     # Returns the cost factor which will result in computation times less than +upper_time_limit_in_ms+.

--- a/spec/bcrypt/engine_spec.rb
+++ b/spec/bcrypt/engine_spec.rb
@@ -58,6 +58,7 @@ describe "Generating BCrypt hashes" do
 
   specify "should raise an InvalidSecret error if the secret is invalid" do
     expect { BCrypt::Engine.hash_secret(MyInvalidSecret.new, @salt) }.to raise_error(BCrypt::Errors::InvalidSecret)
+    expect { BCrypt::Engine.hash_secret("poison\0null", @salt) }.to raise_error(BCrypt::Errors::InvalidSecret)
     expect { BCrypt::Engine.hash_secret(nil, @salt) }.not_to raise_error
     expect { BCrypt::Engine.hash_secret(false, @salt) }.not_to raise_error
   end


### PR DESCRIPTION
When secret passed to bcrypt contains NULL byte, it will be
interpreted as C string and truncated. The secret passed to bcrypt
might include NULL byte, if the users choose to hash the secret
first.

This patch adds a NULL byte check to Engine::valid_secret? and
secret including NULL byte will now trigger InvalidSecret exception.
This behaviour is modelled after py-bcrypt.
