### PR TITLE
Passwords shouldn't contain NULL bytes

### DIFF
--- a/spec/bcrypt/password_spec.rb
+++ b/spec/bcrypt/password_spec.rb
@@ -31,6 +31,12 @@ describe "Creating a hashed password" do
   specify "should tolerate very long string secrets" do
     expect { BCrypt::Password.create("abcd"*1024) }.not_to raise_error
   end
+
+  specify "blows up when null bytes are in the string" do
+    # JRuby can handle the null bytes
+    skip if RUBY_ENGINE == 'jruby'
+    expect { BCrypt::Password.create( "foo\0bar".chop  ) }.to raise_error
+  end
 end
 
 describe "Reading a hashed password" do


### PR DESCRIPTION
Any bytes after the NULL byte won't be part of the hash because the
hashing function assumes that the input is a NULL byte terminated C
string.  This means we should not allow passwords that contain NULL
bytes as input.

Fixes #115
Fixes #114