### PR TITLE
Test against more JRuby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ rvm:
   - 2.5
   - 2.6
   - ruby-head
+  - jruby-9.0
+  - jruby-9.1
+  - jruby-9.2
   - jruby-head
   - rbx-3
 script: bundle exec rake


### PR DESCRIPTION
We probably shouldn't just be testing against `jruby-head`.

Per [JRuby's roadmap](https://github.com/jruby/jruby/wiki/Roadmap), 1.7 is EOL'd and was 1.9.3 compatible, which [we've also now EOL'd](https://github.com/codahale/bcrypt-ruby/pull/185), so not including `jruby-1.7`.

JRuby 9.0, 9.1, and 9.2 are intended to be MRI 2.2, 2.3, and 2.5 compatible, which we do support, so including them here.

JRuby 9.0 seems to be non-trivially failing, which is curious!  Will look into that before merging this — I think there have been a handful of issues here that jibe with that, so I'll investigate later.  Just getting this PR open in the meantime!