### PR TITLE
Deprecate passing the third argument to `BCrypt::Engine.hash_secret`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+Unreleased:
+  - Deprecate passing the third argument to `BCrypt::Engine.hash_secret` [GH #207 by @sergey-alekseev]
+
 3.1.18 May 16 2022
   - Unlock GVL when calculating hashes and salts [GH #260]
   - Fix compilation warnings in `ext/mri/bcrypt_ext.c` [GH #261]

--- a/lib/bcrypt/engine.rb
+++ b/lib/bcrypt/engine.rb
@@ -53,6 +53,13 @@ module BCrypt
     # Given a secret and a valid salt (see BCrypt::Engine.generate_salt) calculates
     # a bcrypt() password hash. Secrets longer than 72 bytes are truncated.
     def self.hash_secret(secret, salt, _ = nil)
+      unless _.nil?
+        warn "[DEPRECATION] Passing the third argument to " \
+             "`BCrypt::Engine.hash_secret` is deprecated. " \
+             "Please do not pass the third argument which " \
+             "is currently not used."
+      end
+
       if valid_secret?(secret)
         if valid_salt?(salt)
           if RUBY_PLATFORM == "java"


### PR DESCRIPTION
Re https://github.com/codahale/bcrypt-ruby/pull/74#issuecomment-492277126.