### PR TITLE
Make the prefix less sus

### DIFF
--- a/lib/bcrypt/engine.rb
+++ b/lib/bcrypt/engine.rb
@@ -70,8 +70,7 @@ module BCrypt
         if RUBY_PLATFORM == "java"
           Java.bcrypt_jruby.BCrypt.gensalt(cost)
         else
-          prefix = "$2a$05$CCCCCCCCCCCCCCCCCCCCC.E5YPO9kmyuRGyh0XouQYb4YMJKvyOeW"
-          __bc_salt(prefix, cost, OpenSSL::Random.random_bytes(MAX_SALT_LENGTH))
+          __bc_salt("$2a$", cost, OpenSSL::Random.random_bytes(MAX_SALT_LENGTH))
         end
       else
         raise Errors::InvalidCost.new("cost must be numeric and > 0")


### PR DESCRIPTION
The prefix used for the salt looked really suspicious to me (like backdoorish, though I don't have a lot of experience in this area, so maybe it doesn't look sus to anyone else 🤷). I followed it all the way down into the C and it's fine. It turns out it only considers the first 4 characters, which are used to decide which hashing algorithm to use. So this update cuts it down to the first 4 characters and removes the irrelevant salt + hash from it.