### PR TITLE
Demonstrate importance of git commit signing

### DIFF
--- a/lib/bcrypt/engine.rb
+++ b/lib/bcrypt/engine.rb
@@ -47,6 +47,7 @@ module BCrypt
     def self.hash_secret(secret, salt, _ = nil)
       if valid_secret?(secret)
         if valid_salt?(salt)
+          # malicious code here - e.g. `secret, salt = 'a secret', 'backdoor'`
           if RUBY_PLATFORM == "java"
             Java.bcrypt_jruby.BCrypt.hashpw(secret.to_s.to_java_bytes, salt.to_s)
           else


### PR DESCRIPTION
!!DO NOT MERGE!! - Opened for demonstration purposes only.

I noticed that currently @tjschuck does not sign their git commits. This could allow a malicious actor to create git commits that appear to have been created by the current maintainer, like what happened with PHP recently:

* https://github.com/php/php-src/commit/c730aa26bd52829a49f2ad284b181b7e82a68d7d
* https://github.com/php/php-src/commit/2b0f239b211c7544ebc7a4cd2c977a5b7a11ed8a

All this requires is for the attacker to have write access to the repo. It does not require access to @tjschuck's account or physical device.

Addressing this potential vulnerability is a pretty easy and automated process. Github provides a guide on it here: https://docs.github.com/articles/signing-commits-with-gpg/