### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,8 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
-          - 3.0
+          - '3.0'
+          - 3.1
           - head
           - jruby
           - jruby-head


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.

It also quotes the 3.0 entry, to ensure that a Ruby 3.0.x version is used.  An unquoted 3.0 will be truncated to 3, causing the latest 3.x Ruby (at this time 3.1.0) to be loaded, which is not what's intended.