### PR TITLE
[Bugfix] Fixing a rare bug when calling BCrypt::Engine#hash_secret - which produces nil accidentally 1 out of 500 cases

### DIFF
--- a/ext/mri/bcrypt_ext.c
+++ b/ext/mri/bcrypt_ext.c
@@ -49,6 +49,9 @@ static VALUE bc_salt(VALUE self, VALUE prefix, VALUE count, VALUE input) {
     if(!salt) return Qnil;
 
     str_salt = rb_str_new2(salt);
+
+    RB_GC_GUARD(prefix);
+    RB_GC_GUARD(input);
     free(salt);
 
     return str_salt;
@@ -99,6 +102,8 @@ static VALUE bc_crypt(VALUE self, VALUE key, VALUE setting) {
 
     out = rb_str_new2(value);
 
+    RB_GC_GUARD(key);
+    RB_GC_GUARD(setting);
     free(args.data);
 
     return out;


### PR DESCRIPTION
## Issue

The following script almost always cannot complete in TruffleRuby:

```ruby
require("bcrypt")

1000.times do
	BCrypt::Engine.hash_secret("test", BCrypt::Engine.generate_salt(5))
end
```

At various points it either returns `nil`: https://github.com/bcrypt-ruby/bcrypt-ruby/blob/e402d692b1bfd2623e9cb414afb2bbe190e9e500/ext/mri/bcrypt_ext.c#L98
Or it segfaults:

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007f633b0ec4d5, pid=23812, tid=23812
#
# JRE version: OpenJDK Runtime Environment GraalVM CE 17.0.7-dev+4.1 (17.0.7+4) (build 17.0.7+4-jvmci-23.1-b02)
# Java VM: OpenJDK 64-Bit Server VM GraalVM CE 17.0.7-dev+4.1 (17.0.7+4-jvmci-23.1-b02, mixed mode, sharing, tiered, jvmci, jvmci compiler, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# J 24970 jvmci org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.profiledPERoot([Ljava/lang/Object;)Ljava/lang/Object; jdk.internal.vm.compiler (57 bytes) @ 0x00007f633b0ec4d5 [0x00007f633b0ebce0+0x00000000000007f5] (_crypt_blowfish_rn#1)
#
```

Bisecting pointed out to this line causing the problem: https://github.com/bcrypt-ruby/bcrypt-ruby/blob/e402d692b1bfd2623e9cb414afb2bbe190e9e500/ext/mri/bcrypt_ext.c#L89-L90 as well as https://github.com/bcrypt-ruby/bcrypt-ruby/blob/e402d692b1bfd2623e9cb414afb2bbe190e9e500/ext/mri/bcrypt_ext.c#L38 and https://github.com/bcrypt-ruby/bcrypt-ruby/blob/e402d692b1bfd2623e9cb414afb2bbe190e9e500/ext/mri/bcrypt_ext.c#L40
@eregon pointed out that these operations are not GC safe as the underlying value can be freed before its last use. Adding GC guards fixed the problem.

From the context we've gathered it seems CRuby is a bit more lucky not failing with this right now, though syntactically it seems to be beneficial to have this change equally (hence the fix in the gem).