### PR TITLE
Limit packaged files

### DIFF
--- a/bcrypt.gemspec
+++ b/bcrypt.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
     passwords.
   EOF
 
-  s.files = `git ls-files`.split("\n")
+  s.files = Dir['CHANGELOG', 'COPYING', 'README.md', 'lib/**/*.rb', 'ext/**/*.*']
   s.require_path = 'lib'
 
   s.add_development_dependency 'rake-compiler', '~> 1.2.0'


### PR DESCRIPTION
Limit files included in the gem to the ones that are necessary.

This skips shipping the gem with directories such as `.github`, `spec` and other files that are not normally accessible and arguably should be skipped.

This saves us some bytes in transfer and disk space on all the computers these gems are downloaded to.