### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/bcrypt

### DIFF
--- a/bcrypt.gemspec
+++ b/bcrypt.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |s|
   s.email = "coda.hale@gmail.com"
   s.homepage = "https://github.com/bcrypt-ruby/bcrypt-ruby"
   s.license = "MIT"
+
+  s.metadata["changelog_uri"] = s.homepage + "/blob/master/CHANGELOG"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/bcrypt which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/