### PR TITLE
Add == gotcha that can be unintuitive at first

### DIFF
--- a/lib/bcrypt/password.rb
+++ b/lib/bcrypt/password.rb
@@ -73,6 +73,8 @@ module BCrypt
     #    @password == @password.to_s      # => False
     #    @password.to_s == @password      # => True
     #    @password.to_s == @password.to_s # => True
+    #
+    #    secret == @password              # => probably False, because the secret is not a BCrypt::Password instance.
     def ==(secret)
       super(BCrypt::Engine.hash_secret(secret, @salt))
     end


### PR DESCRIPTION
Closes: https://github.com/bcrypt-ruby/bcrypt-ruby/issues/266

Unless String `==` method is redefined, this should be false. This might be unintuitive at first glance.
```ruby
'string' == BCrypt::Password.create('string') # => False, method of class String is used
BCrypt::Password.create('string') == 'string' # => True, method of class Password is used
```