### PR TITLE
Mark as ractor-safe

### DIFF
--- a/ext/mri/bcrypt_ext.c
+++ b/ext/mri/bcrypt_ext.c
@@ -111,6 +111,10 @@ static VALUE bc_crypt(VALUE self, VALUE key, VALUE setting) {
 
 /* Create the BCrypt and BCrypt::Engine modules, and populate them with methods. */
 void Init_bcrypt_ext(){
+#ifdef HAVE_RB_EXT_RACTOR_SAFE
+    rb_ext_ractor_safe(true);
+#endif
+    
     mBCrypt = rb_define_module("BCrypt");
     cBCryptEngine = rb_define_class_under(mBCrypt, "Engine", rb_cObject);
 


### PR DESCRIPTION
Closes https://github.com/bcrypt-ruby/bcrypt-ruby/issues/278

- [x] I tested my changes locally. 
On MacOS 15.0, 
uname -a: `Darwin mohameds-mbp.lan 24.0.0 Darwin Kernel Version 24.0.0: Mon Aug 12 20:51:54 PDT 2024; root:xnu-11215.1.10~2/RELEASE_ARM64_T6000 arm64`
Ruby versions: 3.1.6 and 3.3.5
Results: `Finished in 5.26 seconds (files took 0.27213 seconds to load)
39 examples, 0 failures`