### PR TITLE
Add ruby 3.4 to CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,6 +25,7 @@ jobs:
           - 3.2
           - 3.3
           - 3.4.0-preview1
+          - 3.4
           - head
           - jruby
           - jruby-head


### PR DESCRIPTION
Verify compatibility with Ruby 3.4 and its minor patches.