### PR TITLE
Add `rdoc` and `benchmark` gems to gemspec

### DIFF
--- a/bcrypt.gemspec
+++ b/bcrypt.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake-compiler', '~> 1.2.0'
   s.add_development_dependency 'rspec', '>= 3'
+  s.add_development_dependency 'rdoc'
+  s.add_development_dependency 'benchmark'
 
   s.rdoc_options += ['--title', 'bcrypt-ruby', '--line-numbers', '--inline-source', '--main', 'README.md']
   s.extra_rdoc_files += ['README.md', 'COPYING', 'CHANGELOG', *Dir['lib/**/*.rb']]


### PR DESCRIPTION
This pull request addresses the following warnings because Ruby 3.5 moves the `rdoc` and `benchmark` to bundled gems.

- Warnings without adding `rdoc` gem

```ruby
$ ruby -v
ruby 3.5.0dev (2025-08-21T01:55:42Z master 60189671f5) +PRISM [x86_64-linux]
$ bundle exec rake compile
Source locally installed gems is ignoring #<Bundler::StubSpecification name=io-console version=0.8.1 platform=ruby> because it is missing extensions
/home/yahonda/src/github.com/bcrypt-ruby/bcrypt-ruby/Rakefile:6: warning: rdoc/task is found in rdoc, which is not part of the default gems since Ruby 3.5.0.
You can add rdoc to your Gemfile or gemspec to fix this error.
rake aborted!
LoadError: cannot load such file -- rdoc/task (LoadError)
/home/yahonda/src/github.com/bcrypt-ruby/bcrypt-ruby/Rakefile:6:in '<top (required)>'
/home/yahonda/.local/share/mise/installs/ruby/trunk/bin/bundle:25:in '<main>'
(See full trace by running task with --trace)
$
```

- Warnings without adding `rdoc` gem

```ruby
$ ruby -v
ruby 3.5.0dev (2025-08-21T01:55:42Z master 60189671f5) +PRISM [x86_64-linux]
$ bundle exec rake compile
Source locally installed gems is ignoring #<Bundler::StubSpecification name=io-console version=0.8.1 platform=ruby> because it is missing extensions
/home/yahonda/src/github.com/bcrypt-ruby/bcrypt-ruby/Rakefile:7: warning: benchmark used to be loaded from the standard library, but is not part of the default gems since Ruby 3.5.0.
You can add benchmark to your Gemfile or gemspec to fix this error.
rake aborted!
LoadError: cannot load such file -- benchmark (LoadError)
/home/yahonda/src/github.com/bcrypt-ruby/bcrypt-ruby/Rakefile:7:in '<top (required)>'
/home/yahonda/.local/share/mise/installs/ruby/trunk/bin/bundle:25:in '<main>'
(See full trace by running task with --trace)
$
```

References:
https://bugs.ruby-lang.org/issues/20309
https://github.com/ruby/ruby/commit/b0d3771bce9dfcffb7467ea34971198cf4b4079e https://github.com/ruby/ruby/commit/86d871d29cda15810d9d60dc1b94a07e9530e0cb